### PR TITLE
feat: add navigation between home and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,10 @@ npm run preview
 - `/` – Home screen showing centered date and time.
 - `/dashboard` – Dashboard with date top-center, time top-right, and Daily/Weekly/Monthly sections.
 
-Time and date update every second via a Svelte store. Real navigation will be added later.
+## Navigation
+
+- Clicking anywhere on the Home screen takes you to the dashboard.
+- The dashboard monitors mouse movement and clicks; after two minutes of inactivity it automatically returns to the home screen.
+- Any activity resets the timer.
+
+Time and date update every second via a Svelte store.

--- a/src/components/Dashboard.svelte
+++ b/src/components/Dashboard.svelte
@@ -1,5 +1,19 @@
 <script>
   import { time, formatTime, formatDateLong } from '../lib/time.js';
+  import { onMount, onDestroy } from 'svelte';
+  import { push as goto } from 'svelte-spa-router';
+  import { trackInactivity, INACTIVITY_LIMIT_MS } from '../lib/navigation.js';
+
+  let tracker;
+
+  onMount(() => {
+    tracker = trackInactivity(() => goto('/'), INACTIVITY_LIMIT_MS);
+    tracker.start();
+  });
+
+  onDestroy(() => {
+    tracker.stop();
+  });
 </script>
 
 <div class="dashboard">

--- a/src/components/Home.svelte
+++ b/src/components/Home.svelte
@@ -1,8 +1,9 @@
 <script>
   import { time, formatTime, formatDateLong } from '../lib/time.js';
+  import { push as goto } from 'svelte-spa-router';
 </script>
 
-<div class="container">
+<div class="container" on:click={() => goto('/dashboard')}>
   <h1 class="date">{formatDateLong($time.now)}</h1>
   <h2 class="clock">{formatTime($time.now)}</h2>
 </div>

--- a/src/lib/navigation.js
+++ b/src/lib/navigation.js
@@ -1,0 +1,24 @@
+export const INACTIVITY_LIMIT_MS = 120000;
+
+export function trackInactivity(callback, timeout = INACTIVITY_LIMIT_MS) {
+  let timer;
+
+  function reset() {
+    clearTimeout(timer);
+    timer = setTimeout(callback, timeout);
+  }
+
+  function start() {
+    reset();
+    window.addEventListener('mousemove', reset);
+    window.addEventListener('click', reset);
+  }
+
+  function stop() {
+    clearTimeout(timer);
+    window.removeEventListener('mousemove', reset);
+    window.removeEventListener('click', reset);
+  }
+
+  return { start, stop, reset };
+}


### PR DESCRIPTION
## Summary
- navigate from Home to Dashboard on click
- auto-return to Home after 2 minutes of inactivity on Dashboard
- add reusable inactivity tracker helper

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b23ba96aa08325b998d23ccb935bd8